### PR TITLE
Created new alternative for DebMes method

### DIFF
--- a/lib/errors.class.php
+++ b/lib/errors.class.php
@@ -30,7 +30,7 @@
    $script='http://'.$_SERVER['SERVER_NAME'].$_SERVER['REQUEST_URI'];
    $description=$script."\nError:\n".$description;
 
-   $log = Logger::getLogger(__METHOD__);
+   $log = getLogger();
    $log->error($description);
 
    if (Defined("DEBUG_MODE")) {

--- a/lib/general.class.php
+++ b/lib/general.class.php
@@ -376,31 +376,56 @@ function setLocalTime($now_date, $diff=0) {
 }
 
 // ---------------------------------------------------------
-function DebMes ($text) 
+/**
+ * @param $text
+ */
+function DebMes($text)
 {
-   //if (ENVIRONMENT != "dev")
-   //   return;
-   
-   // DEBUG MESSAGE LOG
-   if (!is_dir(ROOT.'debmes')) 
-   {
-      mkdir(ROOT.'debmes');
-   }
+  // DEBUG MESSAGE LOG
+  if (!is_dir(ROOT . 'debmes')) {
+    mkdir(ROOT . 'debmes');
+  }
 
-   $log = Logger::getLogger(__METHOD__);
-   $log->debug($text);
-   /*
-   $today_file = ROOT . 'debmes/' . date('Ymd') . '.txt';
-   $f = fopen($today_file, "a+");
- 
-   if ($f) 
-   {
-      fputs($f, date("d.m.Y H:i:s"));
-      fputs($f, "\n$text\n");
-      fclose($f);
-      @chmod($today_file, 0666);  
-   }
-   */
+  $log = Logger::getRootLogger();
+  $log->debug($text);
+}
+
+/**
+ * Method returns logger with meaningful name. In this case much easy to enable\disable
+ * logs depending on requirements
+ * @param $context
+ * If $context is empty or null, then return root logger
+ * If $context is filename or filepath, then return logger with name 'page.filename'
+ * If $context is string, then return logger with name $context
+ * If $context is object, then depending from object class it returns:
+ *  - 'class.object.objectname'
+ *  - 'class.module.modulename'
+ *  - 'class.objectclass'
+ * Example of usage:
+ *  - $log = getLogger();
+ *  - $log = getLogger('MyLogger');
+ *  - $log = getLogger(__FILE__);
+ *  - $log = getLogger($this);
+ * @return Logger
+ */
+function getLogger($context = null)
+{
+  if (empty($context))
+    return Logger::getRootLogger();
+  elseif (is_string($context)) {
+    if (is_file($context))
+      return Logger::getLogger('page.'.basename($context, '.php'));
+    else
+      return Logger::getLogger($context);
+  }
+  elseif (is_a($context, 'objects'))
+    return Logger::getLogger("class.object.$context->object_title");
+  elseif (is_a($context, 'module'))
+    return Logger::getLogger("class.module.$context->name");
+  elseif (is_object($context))
+    return Logger::getLogger('class.'.get_class($context));
+  else
+    return Logger::getRootLogger();
 }
 
 // ---------------------------------------------------------

--- a/lib/log4php/config.xml
+++ b/lib/log4php/config.xml
@@ -7,6 +7,17 @@
       <param name="file" value="debmes/%s.log" />
       <param name="datePattern" value="Y-m-d" />
    </appender>
+    <appender name="objectsFileLog" class="LoggerAppenderDailyFile">
+        <layout class="LoggerLayoutPattern">
+            <param name="conversionPattern" value="%d{H:i:s} %p [%c]: %m %x%n" />
+        </layout>
+        <param name="file" value="debmes/%s.log" />
+        <param name="datePattern" value="Y-m-d" />
+    </appender>
+    <logger name="class.object" additivity="false">
+        <level value="TRACE" />
+        <appender_ref ref="objectsFileLog" />
+    </logger>
    <root>
       <level value="TRACE" />
       <appender_ref ref="default" />

--- a/modules/objects/objects.class.php
+++ b/modules/objects/objects.class.php
@@ -372,14 +372,14 @@ curl_close($ch);
     }
 
 
-                  try {
-                   $success=eval($code);
-                   if ($success===false) {
-                    DebMes("Error in method code: ".$code);
-                   }
-                  } catch(Exception $e){
-                   DebMes('Error: exception '.get_class($e).', '.$e->getMessage().'.');
-                  }
+     try {
+       $success = eval($code);
+       if ($success === false) {
+         getLogger($this)->error(sprintf('Error in "%s.%s" method. Code: %s', $this->object_title, $name, $code));
+       }
+     } catch (Exception $e) {
+       getLogger($this)->error(sprintf('Exception in "%s.%s" method', $this->object_title, $name), $e);
+     }
 
    }
 

--- a/modules/scripts/scripts.class.php
+++ b/modules/scripts/scripts.class.php
@@ -117,34 +117,35 @@ function run() {
   $this->result=$p->result;
 }
 
-/**
-* Title
-*
-* Description
-*
-* @access public
-*/
- function runScript($id, $params='') {
-  $rec=SQLSelectOne("SELECT * FROM scripts WHERE ID='".(int)$id."' OR TITLE LIKE '".DBSafe($id)."'");
-  if ($rec['ID']) {
-   $rec['EXECUTED']=date('Y-m-d H:i:s');
-   if ($params) {
-    $rec['EXECUTED_PARAMS']=serialize($params);
-   }
-   SQLUpdate('scripts', $rec);
+  /**
+   * Title
+   *
+   * Description
+   *
+   * @access public
+   */
+  function runScript($id, $params = '')
+  {
+    $rec = SQLSelectOne("SELECT * FROM scripts WHERE ID='" . (int)$id . "' OR TITLE LIKE '" . DBSafe($id) . "'");
+    if ($rec['ID']) {
+      $rec['EXECUTED'] = date('Y-m-d H:i:s');
+      if ($params) {
+        $rec['EXECUTED_PARAMS'] = serialize($params);
+      }
+      SQLUpdate('scripts', $rec);
 
-                  try {
-                   $code=$rec['CODE'];
-                   $success=eval($code);
-                   if ($success===false) {
-                    DebMes("Error in script code: ".$code);
-                   }
-                  } catch(Exception $e){
-                   DebMes('Error: exception '.get_class($e).', '.$e->getMessage().'.');
-                  }
+      try {
+        $code = $rec['CODE'];
+        $success = eval($code);
+        if ($success === false) {
+          getLogger($this)->error(sprintf('Error in script "%s". Code: %s', $rec['TITLE'], $code));
+        }
+      } catch (Exception $e) {
+        getLogger($this)->error(sprintf('Error in script "%s"', $rec['TITLE']), $e);
+      }
 
+    }
   }
- }
 
 /**
 * BackEnd


### PR DESCRIPTION
Поскольку разбираюсь с проблемами в МД в основном через логирование, то получилось немного улучшить логирование. Благо log4php уже вкрутили ранее. Ниже идут коменты моих комитов. Посмотреть как пользоваться новым методом можно прямо в документации метода или в [юниттестах](https://github.com/dimitrystd/majordomo/blob/master/Test/lib/generalTest.php)
- Added new method getLogger(). It can generate meaningful logger name dep.ending on context. This method should be extended in the future.
- Modified DebMes. No sense to use `__METHOD__` for looger name. `__METHOD__` always returns "DebMes", it doesn't return original caller method name.
- Configured logger "class.object". We don't need a filename if we got error inside evaluate.
- Use new getLogger() for evaluate (only for objects.class.php and scripts.class.php now). It generates meaningful logger name and also it writes object name + method name. Much better to debug issues in custom code.
- Added documentation for getLogger() method.

Теперь стандартные логи выглядят чуточку читабельней. И их можно фильтровать через конфиг

```
21:52:50 TRACE [page.megad]: Got message from MegaDevice (192.168.0.20, pt=1)
21:52:50 TRACE [page.megad]: Object Bedroom2Light will process call
21:52:50 TRACE [class.object.Bedroom2Light]: getOutputPortState method: get state of output = 11 
21:52:50 TRACE [class.object.MegaD1]: getOutput method: http://192.168.0.20/sec/?pt=11&cmd=get returned ON 
21:52:50 TRACE [class.object.MegaD1]: getOutput method: set Bedroom2Light.enabled = 1 
21:52:50 TRACE [class.object.Bedroom2Light]: switchOff method: set output = 11 to 0 
21:52:50 TRACE [class.object.MegaD1]: setOutput method: http://192.168.0.20/sec/?cmd=11:0 
```

Если случилась ошибка при вызове метода, то будет выглядеть
`21:52:50 ERROR [class.object.MegaD1]: Error in "MegaD1.GetOutput" method. Code: $param['name'] = 1`
