### PR TITLE
Added 'last found' and 'previous found' parameters to raiseEvent 

### DIFF
--- a/scripts/cycle_bluetooth.php
+++ b/scripts/cycle_bluetooth.php
@@ -100,12 +100,14 @@ while(1)
                   echo date('Y/m/d H:i:s')." Device found: $mac\n";
                   
                   $rec = SQLSelectOne("SELECT * FROM btdevices WHERE MAC LIKE '" . $mac . "'");
+                  $previous_found = $rec['LAST_FOUND'];
                   $rec['LAST_FOUND'] = date('Y/m/d H:i:s');
                   $rec['LOG']        = 'Device found '. date('Y/m/d H:i:s') . "\n" . $rec['LOG'];
      
                   if (!$rec['ID']) 
                   {
                      $rec['FIRST_FOUND'] = $rec['LAST_FOUND'];
+                     $previous_found = $rec['LAST_FOUND'];
                      $rec['MAC']         = strtolower($mac);
          
                      $rec['TITLE'] = ($title != '') ? 'Устройство: ' . $title : 'Новое устройство';
@@ -124,7 +126,7 @@ while(1)
                      SQLUpdate('btdevices', $rec);
                   }
       
-                  getObject('BlueDev')->raiseEvent("Found", array('mac' => $mac, 'user' => $user['NAME'], 'new' => $new));
+                  getObject('BlueDev')->raiseEvent("Found", array('mac' => $mac, 'user' => $user['NAME'], 'new' => $new, 'previous_found' => $previous_found, 'last_found' => $rec['FIRST_FOUND']));
                } 
                else 
                {


### PR DESCRIPTION
Added 'last found' and 'previous found' parameters to raiseEvent  in cycle_bluetooth module.
This parameters can help to analyse problem with flickering bluetooth devices
