### PR TITLE
Removed useless line from setProperty()

### DIFF
--- a/modules/objects/objects.class.php
+++ b/modules/objects/objects.class.php
@@ -692,7 +692,6 @@ function usual(&$out) {
    global $property_linked_history;
    if (!$property_linked_history[$property][$prop['ONCHANGE']]) {
     $property_linked_history[$property][$prop['ONCHANGE']]=1;
-    global $on_change_called;
     $params=array();
     $params['PROPERTY']=$property;
     $params['NEW_VALUE']=(string)$value;


### PR DESCRIPTION
I removed `global $on_change_called;`from `setProperty()` a long time ago, and now just checked that your code also never uses `$on_change_called`