### PR TITLE
getURLBackground to the Unix system

### DIFF
--- a/lib/common.class.php
+++ b/lib/common.class.php
@@ -769,7 +769,7 @@ function getURL($url, $cache = 0, $username = '', $password = '', $background = 
          curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
 
           if ($background) {
-              //curl_setopt($ch, CURLOPT_TIMEOUT, 1);
+              curl_setopt($ch, CURLOPT_NOSIGNAL, 1);
               curl_setopt($ch, CURLOPT_TIMEOUT_MS, 1);
           }
 


### PR DESCRIPTION
We make a workable method getURLBackground (callMethodSafe and runScriptSafe) to the Unix system.
Делаем работоспособным метод getURLBackground (и соответственно callMethodSafe и runScriptSafe) в юникс системах.

[Особенности работы](http://php.net/manual/ru/function.curl-setopt.php#104597) curl в юникс системах 