### PR TITLE
disable crash system via phpmqtt.php

### DIFF
--- a/lib/mqtt/phpMQTT.php
+++ b/lib/mqtt/phpMQTT.php
@@ -153,7 +153,7 @@ class phpMQTT {
                 $togo = $int;
                 while (!feof($this->socket) && $togo>0) {
                         $togo = $int - strlen($string);
-                        if($togo) $string .= fread($this->socket, $togo);
+                        if($togo>0) $string .= fread($this->socket, $togo);
 
                  if (!$string) {
                   if (!$this->socket) {


### PR DESCRIPTION
if mqtt recieve big packet, variable $togo = 0 and system loops with error:

"length parameter must be greater 0 php mqtt.php on line 156" - it momentaly increase log file log_xxx_mqtt_cycle.txt and disk is full and system crashes