### PR TITLE
Fix: Parse error after auto-formatting source with a condition in the template (jtemplate)

### DIFF
--- a/lib/jTemplate.class.php
+++ b/lib/jTemplate.class.php
@@ -579,6 +579,7 @@ class jTemplate
                $condition = preg_replace('/^!(\w+)$/', '!IsSet($hash[\'\\1\'])', $condition);
                $condition = preg_replace('/^(\w+)$/', 'IsSet($hash[\'\\1\'])', $condition);
                $condition = preg_replace('/(\w+)(?=[=!<>])/', '$hash[\'\\1\']', $condition);
+               $condition = preg_replace('/(\w+)[[:space:]](?=[=!<>])/', '$hash[\'\\1\']', $condition);
                $condition = preg_replace('/\((\w+)\)/', '($hash[\'\\1\'])', $condition);
                $condition = preg_replace('/\]=(?=[^\w=])/', ']==', $condition);
 


### PR DESCRIPTION
 Fix: Parse error after auto-formatting source with a condition in the template (jtemplate)

Error message:
```php
Parse error: syntax error, unexpected '=' in \var\www\mdm\lib\jTemplate.class.php(587) : eval()'d code on line 1
```

Before auto-format:
```
[#if TYPE="app"#]
```
Afrer auto-format:
```
 [#if TYPE = "app"#]
```