### PR TITLE
Заведомо пустое поле типа устройств

### DIFF
--- a/modules/devices/devices.class.php
+++ b/modules/devices/devices.class.php
@@ -683,7 +683,7 @@ function usual(&$out) {
     
  function addDevice($device_type, $options=0) {
      $this->setDictionary();
-     $type_details=$this->getTypeDetails($rec['TYPE']);
+     $type_details=$this->getTypeDetails($device_type);
 
      if (!is_array($options)) {
          $options=array();


### PR DESCRIPTION
При создании простых устройств - заведомо неправильные данные приходят о типе устройства . Просто эта запись не передается.
А так работает полгода без сбоев....