### PR TITLE
switch RO

### DIFF
--- a/modules/commands/commands.class.php
+++ b/modules/commands/commands.class.php
@@ -358,10 +358,11 @@ function admin(&$out) {
     $tmpdata=explode("\n", str_replace("\r", "", $item['DATA'])); // находим признак RO на 1 или 3 позиции
     $tmpdatac = count($tmpdata);
     if ($tmpdatac==1) {
-     $swro = ($tmpdata[0] == 'RO');
+      
+     $swro = (trim($data[0]) == 'RO');
      }
     if ($tmpdatac==3) {
-     $swro = ($tmpdata[2] == 'RO');
+     $swro = (trim($data[2]) == 'RO');
      }
     
     if ( !($item['TYPE']=='switch' && $swro) ){

--- a/modules/commands/commands.class.php
+++ b/modules/commands/commands.class.php
@@ -359,10 +359,10 @@ function admin(&$out) {
     $tmpdatac = count($tmpdata);
     if ($tmpdatac==1) {
       
-     $swro = (trim($data[0]) == 'RO');
+     $swro = (trim($tmpdata[0]) == 'RO');
      }
     if ($tmpdatac==3) {
-     $swro = (trim($data[2]) == 'RO');
+     $swro = (trim($tmpdata[2]) == 'RO');
      }
     
     if ( !($item['TYPE']=='switch' && $swro) ){

--- a/modules/commands/commands.class.php
+++ b/modules/commands/commands.class.php
@@ -355,11 +355,21 @@ function admin(&$out) {
      $item['LINKED_OBJECT']=$object_rec['TITLE'];
     }
 
-    if ($item['LINKED_PROPERTY']!='') {
-     sg($item['LINKED_OBJECT'].'.'.$item['LINKED_PROPERTY'], $item['CUR_VALUE'], array($this->name=>'ID!='.$item['ID']));
-    }
-
-    $params=array('VALUE'=>$item['CUR_VALUE'], 'OLD_VALUE'=>$old_value);
+    $tmpdata=explode("\n", str_replace("\r", "", $item['DATA'])); // находим признак RO на 1 или 3 позиции
+    $tmpdatac = count($tmpdata);
+    if ($tmpdatac==1) {
+     $swro = ($tmpdata[0] == 'RO');
+     }
+    if ($tmpdatac==3) {
+     $swro = ($tmpdata[2] == 'RO');
+     }
+    
+    if ( !($item['TYPE']=='switch' && $swro) ){
+      if ($item['LINKED_PROPERTY']!='') {
+       sg($item['LINKED_OBJECT'].'.'.$item['LINKED_PROPERTY'], $item['CUR_VALUE'], array($this->name=>'ID!='.$item['ID']));
+       }
+      }
+      $params=array('VALUE'=>$item['CUR_VALUE'], 'OLD_VALUE'=>$old_value);
 
     if ($item['ONCHANGE_METHOD']!='') {
      if (!$item['LINKED_OBJECT']) {
@@ -748,15 +758,27 @@ function usual(&$out) {
     $res[$i]=$item;
    }
 
-   if ($item['TYPE']=='switch') {
+   if ($item['TYPE']=='switch') {     
+    $item['OFF_VALUE']=0;
+    $item['ON_VALUE']=1;
+
     if (trim($item['DATA'])) {
      $data=explode("\n", str_replace("\r", "", $item['DATA']));
-     $item['OFF_VALUE']=trim($data[0]);
-     $item['ON_VALUE']=trim($data[1]);
-    } else {
-     $item['OFF_VALUE']=0;
-     $item['ON_VALUE']=1;
-    }
+     $datac = count($data);
+     if ($datac==1) {
+      $item+= array('RO' => trim($data[0]));
+      }
+      if ($datac==2){
+        $item['OFF_VALUE']=trim($data[0]);
+        $item['ON_VALUE']=trim($data[1]);
+       }
+     if ($datac==3){
+       $item['OFF_VALUE']=trim($data[0]);
+       $item['ON_VALUE']=trim($data[1]);
+       $item+= array('RO'=> trim($data[2]));
+      }
+    } 
+    
     $res[$i]=$item;
    }
 


### PR DESCRIPTION
Для обеспечения обратной связи, чтобы выключатель не портил значения своейства статус у устройств.
Если в поле DATA есть строка 'RO' - то выключатель не меняет связанное свойство. Если в поле есть 3 строки, то 2 первые рассматриваются как альтернативные значения off и on, а третья проверяется на RO.
Я ниразу не видел использования поля DATA для выключателя. Поэтому в большинстве случаев достаточно будет занести в поле "RO".
Еще нужно доделать фронтэнд, чтобы выключатель после нажатия возвращался в начальное положение, или третье состояние, пока устройство не установит статус и не придет актуальное состояние. (сейчас выключатель переключается, и стоит в новом состоянии пока не придет новый статус)