### PR TITLE
Выбор изображения для элемента "Изображение".

### DIFF
--- a/templates/scenes/elements_edit.html
+++ b/templates/scenes/elements_edit.html
@@ -516,12 +516,6 @@
                 </p>
         </div>
 </div>
-<script type="text/javascript">
-     function openFileBrowser(id){
-          fileBrowserlink = "<#ROOTHTML#>3rdparty/pdw/index.php?editor=standalone&returnID=" + id;
-          window.open(fileBrowserlink,'pdwfilebrowser', 'width=1000,height=650,scrollbars=no,toolbar=no,location=no');
-     }
-</script>
 [#endif ELEMENT_TYPE#]
 
 [#if ELEMENT_TYPE!="container" && ELEMENT_TYPE!="device"#]


### PR DESCRIPTION
По всей видимости, проблема возникла после перехода на новый ФМ.
Вырезал функцию openFileBrowser для выбора изображения для элемента сцены "Изображение".