### PR TITLE
timenow без обращения к базе

### DIFF
--- a/lib/objects.class.php
+++ b/lib/objects.class.php
@@ -586,7 +586,7 @@ function getGlobal($varname)
    {
       $object_name = 'ThisComputer';
    }
-
+   if (!strcasecmp($object_name.'.'.$varname, "ThisComputer.timeNow")) return date("H:i"); // to not save into the cache
    $cached_name  = 'MJD:' . $object_name . '.' . $varname;
    $cached_value = checkFromCache($cached_name);
 

--- a/modules/objects/objects.class.php
+++ b/modules/objects/objects.class.php
@@ -633,6 +633,8 @@ function usual(&$out) {
  function getProperty($property) {
 
   $property = trim($property);
+  
+  if (!strcasecmp($this->object_title.'.'.$property, "ThisComputer.timeNow")) return date("H:i");
 
   if ($this->object_title) {
    $value=SQLSelectOne("SELECT VALUE FROM pvalues WHERE PROPERTY_NAME = '".DBSafe($this->object_title.'.'.$property)."'");
@@ -695,6 +697,8 @@ function usual(&$out) {
   startMeasure('setProperty ('.$property.')');
 
   $property = trim($property);
+
+  if (!strcasecmp($this->object_title.'.'.$property, "ThisComputer.timeNow")) return;
 
   if (is_null($value)) {
    $value='';


### PR DESCRIPTION
Храниить текущее время в базе ради удобства доступа - расточительно) Поэтому просто отдаем его сразу по запросу. Возможно лучше его вообще убрать, мало где используется (но тем неменее создает хоть и небольшую, но бессмысленную нагрузку на базу)