### PR TITLE
Внесено в терминалы поле Controlladdres

### DIFF
--- a/modules/terminals/terminals.class.php
+++ b/modules/terminals/terminals.class.php
@@ -211,6 +211,7 @@ terminals - Terminals
  terminals: PLAYER_PORT varchar(255) NOT NULL DEFAULT ''
  terminals: PLAYER_USERNAME varchar(255) NOT NULL DEFAULT ''
  terminals: PLAYER_PASSWORD varchar(255) NOT NULL DEFAULT ''
+ terminals: PLAYER_CONTROL_ADDRES varchar(255) NOT NULL DEFAULT ''
  terminals: IS_ONLINE int(3) NOT NULL DEFAULT '0'
  terminals: MAJORDROID_API int(3) NOT NULL DEFAULT '0'
  terminals: LATEST_REQUEST varchar(255) NOT NULL DEFAULT ''

--- a/modules/terminals/terminals_edit.inc.php
+++ b/modules/terminals/terminals_edit.inc.php
@@ -43,6 +43,9 @@
    global $level_linked_property;
    $rec['LEVEL_LINKED_PROPERTY']=$level_linked_property;
 
+   global $controll_addres;
+   $rec['PLAYER_CONTROL_ADDRES']=$controll_addres;
+
    if ($rec['TITLE']=='') {
     $out['ERR_TITLE']=1;
     $ok=0;

--- a/templates/terminals/terminals_edit.html
+++ b/templates/terminals/terminals_edit.html
@@ -144,6 +144,11 @@
 				function player_type_select(type) {
 					$('small.addon-description').addClass('hidden');
 					$('small#'+type+'_description').removeClass('hidden');
+                                        if (type == 'dnla') {
+                                           $('#dla_controladdres').show();
+                                           } else {
+                                           $('#dla_controladdres').hide();
+                                           }
 					return true;
 				}
 				$(document).ready(function() {
@@ -164,6 +169,12 @@
 		<label class="col-lg-4 control-label" for="inputTitle"><#LANG_PLAYER_PASSWORD#>:</label>
 		<div class="col-lg-5"><input type="text"  class="form-control"  name="player_password" value="[#PLAYER_PASSWORD#]"></div>
 	</div>
+
+	<div id='dla_controladdres' style="display:none" class="form-group ">
+		<label class="col-lg-4 control-label" for="inputTitle">Controll adress:</label>
+		<div class="col-lg-5"><input type="text"  class="form-control"  name="player_controll_addres" value="[#PLAYER_CONTROL_ADDRES#]"></div>
+	</div>
+        
 </div>
 
 <div class="form-group">


### PR DESCRIPTION
Отображается только для ДНЛА устройств. В последствии для других устройств - при необходимости можна добавлять