### PR TITLE
optimize needless sql like

### DIFF
--- a/command.php
+++ b/command.php
@@ -62,7 +62,7 @@ if ($qry != '' && $qry != $lastest_word)
 
 
    if ($username) {
-       $user    = SQLSelectOne("SELECT ID FROM users WHERE USERNAME LIKE '".DBSafe(trim($username))."'");
+       $user    = SQLSelectOne("SELECT ID FROM users WHERE USERNAME = '".DBSafe(trim($username))."'");
        $user_id = (int)$user['ID'];
    }
 

--- a/lib/common.class.php
+++ b/lib/common.class.php
@@ -383,7 +383,7 @@ function addScheduledJob($title, $commands, $datetime, $expire = 1800)
  */
 function clearScheduledJob($title)
 {
-   SQLExec("DELETE FROM jobs WHERE TITLE LIKE '" . DBSafe($title) . "'");
+   SQLExec("DELETE FROM jobs WHERE TITLE = '" . DBSafe($title) . "'");
 }
 
 /**
@@ -428,7 +428,7 @@ function clearTimeOut($title)
  */
 function timeOutExists($title)
 {
-   $job = SQLSelectOne("SELECT ID FROM jobs WHERE PROCESSED = 0 AND TITLE LIKE '" . DBSafe($title) . "'");
+   $job = SQLSelectOne("SELECT ID FROM jobs WHERE PROCESSED = 0 AND TITLE = '" . DBSafe($title) . "'");
    return (int)$job['ID'];
 }
 
@@ -980,8 +980,8 @@ function isOnline($host)
 {
    $sqlQuery = "SELECT *
                   FROM pinghosts
-                 WHERE HOSTNAME LIKE '" . DBSafe($host) . "'
-                    OR TITLE LIKE    '" . DBSafe($host) . "'";
+                 WHERE HOSTNAME = '" . DBSafe($host) . "'
+                    OR TITLE =    '" . DBSafe($host) . "'";
 
    $rec = SQLSelectOne($sqlQuery);
    if (!$rec['STATUS'] || $rec['STATUS'] == 2)
@@ -1026,7 +1026,7 @@ function registerError($code = 'custom', $details = '')
     return 0;
    }
 
-   $error_rec = SQLSelectOne("SELECT * FROM system_errors WHERE CODE LIKE '" . DBSafe($code) . "'");
+   $error_rec = SQLSelectOne("SELECT * FROM system_errors WHERE CODE = '" . DBSafe($code) . "'");
 
    if (!$error_rec['ID'])
    {

--- a/lib/objects.class.php
+++ b/lib/objects.class.php
@@ -22,7 +22,7 @@ function addClass($class_name, $parent_class = '')
 
    $sqlQuery = "SELECT ID
                   FROM classes
-                 WHERE TITLE LIKE '" . DBSafe($class_name) . "'";
+                 WHERE TITLE = '" . DBSafe($class_name) . "'";
 
    $class = SQLSelectOne($sqlQuery);
 
@@ -111,7 +111,7 @@ function addClassMethod($class_name, $method_name, $code = '', $key = '')
       $sqlQuery = "SELECT * 
                      FROM methods
                     WHERE CLASS_ID = '" . $class_id . "'
-                      AND TITLE LIKE '" . DBSafe($method_name) . "'
+                      AND TITLE = '" . DBSafe($method_name) . "'
                       AND OBJECT_ID = 0";
 
       $method = SQLSelectOne($sqlQuery);
@@ -168,7 +168,7 @@ function addClassProperty($class_name, $property_name, $keep_history = 0)
 
    $sqlQuery = "SELECT ID
                   FROM properties
-                 WHERE TITLE LIKE '" . DBSafe($property_name) . "'
+                 WHERE TITLE = '" . DBSafe($property_name) . "'
                    AND OBJECT_ID = 0
                    AND CLASS_ID  = '" . $class_id . "'";
 
@@ -199,7 +199,7 @@ function addClassObject($class_name, $object_name, $system='')
    $class_id = addClass($class_name);
    $sqlQuery = "SELECT ID
                   FROM objects
-                 WHERE TITLE LIKE '" . DBSafe($object_name) . "'";
+                 WHERE TITLE = '" . DBSafe($object_name) . "'";
    
    $object = SQLSelectOne($sqlQuery);
    
@@ -373,8 +373,8 @@ function getObject($name)
       $sqlQuery = "SELECT objects.*
                      FROM objects
                      LEFT JOIN classes ON objects.CLASS_ID = classes.ID
-                    WHERE objects.TITLE LIKE '" . DBSafe($object_name) . "'
-                      AND classes.TITLE LIKE '" . DBSafe($class_name) . "'";
+                    WHERE objects.TITLE = '" . DBSafe($object_name) . "'
+                      AND classes.TITLE = '" . DBSafe($class_name) . "'";
 
       $rec = SQLSelectOne($sqlQuery);
    }
@@ -382,10 +382,10 @@ function getObject($name)
    {
       $sqlQuery = "SELECT objects.*
                      FROM objects
-                    WHERE TITLE LIKE '" . DBSafe($name) . "'";
+                    WHERE TITLE = '" . DBSafe($name) . "'";
 
       $rec = SQLSelectOne($sqlQuery);
-      //$rec = SQLSelectOne("SELECT objects.* FROM objects WHERE TITLE LIKE '".DBSafe($name)."'");
+      //$rec = SQLSelectOne("SELECT objects.* FROM objects WHERE TITLE = '".DBSafe($name)."'");
    }
    
    if ($rec['ID'])
@@ -414,7 +414,7 @@ function getObjectsByProperty($property_name, $condition='', $condition_value=''
         $condition_value=$condition;
         $condition='==';
     }
-  $pRecs=SQLSelect("SELECT ID FROM properties WHERE TITLE LIKE '".DBSafe($property_name)."'");
+  $pRecs=SQLSelect("SELECT ID FROM properties WHERE TITLE = '".DBSafe($property_name)."'");
   $total=count($pRecs);
   if (!$total) {
    return 0;
@@ -460,7 +460,7 @@ function getObjectsByClass($class_name)
 {
    $sqlQuery = "SELECT ID
                   FROM classes
-                 WHERE (TITLE LIKE '" . DBSafe(trim($class_name)) . "'
+                 WHERE (TITLE = '" . DBSafe(trim($class_name)) . "'
                         OR ID = " . (int)$class_name . "
                        )";
 
@@ -516,7 +516,7 @@ function getClassProperties($class_id, $def='') {
     global $cached_class_properties;
     if (isset($cached_class_properties[$class_id])) return $cached_class_properties[$class_id];
 
-    $class=SQLSelectOne("SELECT ID, PARENT_ID FROM classes WHERE (ID='".(int)$class_id."' OR TITLE LIKE '".DBSafe($class_id)."')");
+    $class=SQLSelectOne("SELECT ID, PARENT_ID FROM classes WHERE (ID='".(int)$class_id."' OR TITLE = '".DBSafe($class_id)."')");
     $properties=SQLSelect("SELECT properties.*, classes.TITLE as CLASS_TITLE FROM properties LEFT JOIN classes ON properties.CLASS_ID=classes.ID WHERE CLASS_ID='".$class['ID']."' AND OBJECT_ID=0");
     $res=$properties;
     if (!is_array($def)) {
@@ -1256,7 +1256,7 @@ function getRoomObjectByLocation($location_id,$auto_add=0) {
     if (!$location_title) {
         $location_title='Room'.$location_id;
     }
-    $room_object=SQLSelectOne("SELECT * FROM objects WHERE TITLE LIKE '".DBSafe($location_title)."'");
+    $room_object=SQLSelectOne("SELECT * FROM objects WHERE TITLE = '".DBSafe($location_title)."'");
     if ($room_object['ID']) return $room_object['TITLE'];
 
     $class_id=addClass("Rooms");
@@ -1278,7 +1278,7 @@ function getUserObjectByTitle($user_id,$auto_add=0) {
     if (!$user_title) {
         $user_title='User'.$user_id;
     }
-    $user_object=SQLSelectOne("SELECT * FROM objects WHERE (TITLE LIKE '".DBSafe($user_title)."' OR (DESCRIPTION!='' AND DESCRIPTION LIKE '".$user_rec['NAME']."'))");
+    $user_object=SQLSelectOne("SELECT * FROM objects WHERE (TITLE = '".DBSafe($user_title)."' OR (DESCRIPTION!='' AND DESCRIPTION = '".$user_rec['NAME']."'))");
     if ($user_object['ID']) return $user_object['TITLE'];
     if ($auto_add) {
         $object_id=addClassObject("Users",$user_title);
@@ -1290,7 +1290,7 @@ function getUserObjectByTitle($user_id,$auto_add=0) {
 }
 
 function deleteObject($object_id) {
-    $object_rec=SQLSelectOne("SELECT ID FROM objects WHERE ID=".(int)$object_id." OR TITLE LIKE '".DBSafe($object_id)."'");
+    $object_rec=SQLSelectOne("SELECT ID FROM objects WHERE ID=".(int)$object_id." OR TITLE = '".DBSafe($object_id)."'");
     if ($object_rec['ID']) {
         include_once(DIR_MODULES.'objects/objects.class.php');
         $obj=new objects();
@@ -1322,7 +1322,7 @@ function objectClassChanged($object_id) {
     $properties=$obj->getParentProperties($rec['CLASS_ID'], '', 1);
     $total=count($properties);
     for($i=0;$i<$total;$i++) {
-        $pvalue=SQLSelectOne("SELECT pvalues.* FROM pvalues LEFT JOIN properties ON pvalues.PROPERTY_ID=properties.ID WHERE properties.CLASS_ID=0 AND pvalues.OBJECT_ID='".$rec['ID']."' AND properties.TITLE LIKE '".DBSafe($properties[$i]['TITLE'])."'");
+        $pvalue=SQLSelectOne("SELECT pvalues.* FROM pvalues LEFT JOIN properties ON pvalues.PROPERTY_ID=properties.ID WHERE properties.CLASS_ID=0 AND pvalues.OBJECT_ID='".$rec['ID']."' AND properties.TITLE = '".DBSafe($properties[$i]['TITLE'])."'");
         if ($pvalue['ID']) {
             $old_prop=$pvalue['PROPERTY_ID'];
             $pvalue['PROPERTY_ID']=$properties[$i]['ID'];

--- a/lib/terminals.class.php
+++ b/lib/terminals.class.php
@@ -21,7 +21,7 @@ function getTerminalByID($id) {
 
 // Get terminal by name
 function getTerminalsByName($name, $limit = -1, $order = 'ID', $sort = 'ASC') {
-	$sqlQuery = "SELECT * FROM `terminals` WHERE `NAME` LIKE '".DBSafe($name)."' OR `TITLE` LIKE '".DBSafe($name)."' ORDER BY `".DBSafe($order)."` ".DBSafe($sort);
+	$sqlQuery = "SELECT * FROM `terminals` WHERE `NAME` = '".DBSafe($name)."' OR `TITLE` = '".DBSafe($name)."' ORDER BY `".DBSafe($order)."` ".DBSafe($sort);
 	if($limit >= 0) {
 		$sqlQuery .= ' LIMIT '.intval($limit);
 	}
@@ -44,9 +44,9 @@ function getTerminalsByHost($host, $limit = -1, $order = 'ID', $sort = 'ASC') {
 		'0:0:0:0:0:0:0:1',
 	);
 	if(in_array(strtolower($host), $localhost)) {
-		$sqlQuery = "SELECT * FROM `terminals` WHERE `HOST` LIKE '".implode("' OR `HOST` LIKE '", $localhost)."' ORDER BY `".DBSafe($order)."` ".DBSafe($sort);
+		$sqlQuery = "SELECT * FROM `terminals` WHERE `HOST` = '".implode("' OR `HOST` = '", $localhost)."' ORDER BY `".DBSafe($order)."` ".DBSafe($sort);
 	} else {
-		$sqlQuery = "SELECT * FROM `terminals` WHERE `HOST` LIKE '".DBSafe($host)."' ORDER BY `".DBSafe($order)."` ".DBSafe($sort);
+		$sqlQuery = "SELECT * FROM `terminals` WHERE `HOST` = '".DBSafe($host)."' ORDER BY `".DBSafe($order)."` ".DBSafe($sort);
 	}
 	if($limit >= 0) {
 		$sqlQuery .= ' LIMIT '.intval($limit);
@@ -83,7 +83,7 @@ function getTerminalsByPlayer($player, $limit = -1, $order = 'ID', $sort = 'ASC'
 
 // Get main terminal
 function getMainTerminal() {
-	$sqlQuery = "SELECT * FROM `terminals` WHERE `NAME` LIKE 'MAIN'";
+	$sqlQuery = "SELECT * FROM `terminals` WHERE `NAME` = 'MAIN'";
 	$terminal = SQLSelectOne($sqlQuery);
 	return $terminal;
 }

--- a/modules/classes/classes.class.php
+++ b/modules/classes/classes.class.php
@@ -215,7 +215,7 @@ function admin(&$out) {
   if (is_array($records)) {
    $total=count($records);
    for($i=0;$i<$total;$i++) {
-    $old_class=SQLSelectOne("SELECT ID FROM classes WHERE TITLE LIKE '".DBSafe($records[$i]['TITLE'])."'");
+    $old_class=SQLSelectOne("SELECT ID FROM classes WHERE TITLE = '".DBSafe($records[$i]['TITLE'])."'");
     $total_o=0;
     if ($old_class['ID']) {
      $old_objects=SQLSelect("SELECT * FROM objects WHERE CLASS_ID='".$old_class['ID']."'");
@@ -239,7 +239,7 @@ function admin(&$out) {
     $properties=$records[$i]['PROPERTIES'];
     unset($records[$i]['PROPERTIES']);
     if ($records[$i]['PARENT_CLASS']) {
-     $parent_class=SQLSelectOne("SELECT ID FROM classes WHERE TITLE LIKE '".DBSafe($records[$i]['PARENT_CLASS'])."'");
+     $parent_class=SQLSelectOne("SELECT ID FROM classes WHERE TITLE = '".DBSafe($records[$i]['PARENT_CLASS'])."'");
      if ($parent_class['ID']) {
       $records[$i]['PARENT_ID']=$parent_class['ID'];
      }

--- a/modules/commands/commands.class.php
+++ b/modules/commands/commands.class.php
@@ -875,7 +875,7 @@ function usual(&$out) {
 * @access public
 */
  function propertySetHandle($object, $property, $value) {
-   $commands=SQLSelect("SELECT * FROM commands WHERE LINKED_OBJECT LIKE '".DBSafe($object)."' AND LINKED_PROPERTY LIKE '".DBSafe($property)."'");
+   $commands=SQLSelect("SELECT * FROM commands WHERE LINKED_OBJECT = '".DBSafe($object)."' AND LINKED_PROPERTY = '".DBSafe($property)."'");
    $total=count($commands);
    for($i=0;$i<$total;$i++) {
     $commands[$i]['CUR_VALUE']=$value;

--- a/modules/objects/objects.class.php
+++ b/modules/objects/objects.class.php
@@ -406,7 +406,7 @@ function usual(&$out) {
   function getMethodByName($name, $class_id, $id) {
 
    if ($id) {
-    $meth=SQLSelectOne("SELECT ID FROM methods WHERE OBJECT_ID='".(int)$id."' AND TITLE LIKE '".DBSafe($name)."'");
+    $meth=SQLSelectOne("SELECT ID FROM methods WHERE OBJECT_ID='".(int)$id."' AND TITLE = '".DBSafe($name)."'");
     if ($meth['ID']) {
      return $meth['ID'];
     }
@@ -600,7 +600,7 @@ function usual(&$out) {
 * @access public
 */
  function getPropertyByName($name, $class_id, $object_id) {
-  $rec=SQLSelectOne("SELECT ID FROM properties WHERE OBJECT_ID='".(int)$object_id."' AND TITLE LIKE '".DBSafe($name)."'");
+  $rec=SQLSelectOne("SELECT ID FROM properties WHERE OBJECT_ID='".(int)$object_id."' AND TITLE = '".DBSafe($name)."'");
   if ($rec['ID']) {
    return $rec['ID'];
   }

--- a/modules/patterns/patterns.class.php
+++ b/modules/patterns/patterns.class.php
@@ -541,7 +541,7 @@ class patterns extends module
 
     function propertySetHandle($object, $property, $value)
     {
-        $patterns = SQLSelect("SELECT ID FROM patterns WHERE PATTERN_TYPE=1 AND LINKED_OBJECT LIKE '" . DBSafe($object) . "' AND LINKED_PROPERTY LIKE '" . DBSafe($property) . "'");
+        $patterns = SQLSelect("SELECT ID FROM patterns WHERE PATTERN_TYPE=1 AND LINKED_OBJECT = '" . DBSafe($object) . "' AND LINKED_PROPERTY = '" . DBSafe($property) . "'");
         $total = count($patterns);
         if ($total) {
             for ($i = 0; $i < $total; $i++) {

--- a/modules/scenes/scenes.class.php
+++ b/modules/scenes/scenes.class.php
@@ -437,7 +437,7 @@ function admin(&$out) {
   }
   if ($data['SCENE_DATA']) {
    if ($system!='') {
-    $old_rec=SQLSelectOne("SELECT ID FROM scenes WHERE SYSTEM LIKE '".DBSafe($system)."'");
+    $old_rec=SQLSelectOne("SELECT ID FROM scenes WHERE SYSTEM = '".DBSafe($system)."'");
     if ($old_rec['ID']) {
      return;
     }

--- a/modules/scripts/scripts.class.php
+++ b/modules/scripts/scripts.class.php
@@ -137,7 +137,7 @@ class scripts extends module
 
         verbose_log("Script [" . $id . "] (" . is_array($params) ? json_encode($params) : '' . ")");
 
-        $rec = SQLSelectOne("SELECT * FROM scripts WHERE ID='" . (int)$id . "' OR TITLE LIKE '" . DBSafe($id) . "'");
+        $rec = SQLSelectOne("SELECT * FROM scripts WHERE ID='" . (int)$id . "' OR TITLE = '" . DBSafe($id) . "'");
         if ($rec['ID']) {
             $rec['EXECUTED'] = date('Y-m-d H:i:s');
             if ($params) {

--- a/scripts/cycle_main.php
+++ b/scripts/cycle_main.php
@@ -25,7 +25,7 @@ getObject('ThisComputer')->raiseEvent("StartUp");
 
 $sqlQuery = "SELECT *
                FROM classes
-              WHERE TITLE LIKE 'timer'";
+              WHERE TITLE = 'timer'";
 
 $timerClass = SQLSelectOne($sqlQuery);
 $o_qry = 1;


### PR DESCRIPTION
Замена в SQL like на =. Во-первых like заставляет просматривать всю таблицу, вместо выбора одного значения, что еще хуже в сложных запросах c join и sort. 
Посидел вечерок поделал explain - во многих случаях удалось ускорить в десятки раз.
Ну и в конце концов запросы типа  SELECT ID FROM properties WHERE OBJECT_ID='7' AND TITLE LIKE 'cycle_watchfoldersRun'  без шаблона не просто выглядят нелепо, а еще и зазря сканируют по 70 строк вместо одной.
В некоторых случаях это  даже опасно, например $user    = SQLSelectOne("SELECT ID FROM users WHERE USERNAME LIKE '".DBSafe(trim($username))."'");  Если в системе есть 2 юзера vasia и vasia1 то  vas% может вернуть не то, что планировалось)
Допускаю, что в некоторых случаях может быть удобно писать clearScheduledJob('myjob%') но  это псевдоудобство ценой производительности, которая и так не блещет.