### PR TITLE
Исправление кодировки заголовка емейла

### DIFF
--- a/lib/htmlMimeMail.class.php
+++ b/lib/htmlMimeMail.class.php
@@ -667,6 +667,7 @@ class htmlMimeMail
     */
    function _encodeHeader($input, $charset = 'ISO-8859-1')
    {
+      /*
       preg_match_all('/(\s?\w*[\x80-\xFF]+\w*\s?)/', $input, $matches);
 
       foreach ($matches[1] as $value)
@@ -676,6 +677,7 @@ class htmlMimeMail
       }
 
       return $input;
+      */
    }
 
    /**


### PR DESCRIPTION
Продолжение исправления кодировки для емейла
https://github.com/sergejey/majordomo/pull/398
т.к. мы в комите 398 исправили уже кодировки тела письма, то и нет необходимости изменять кодировки заголовка. Старая функция ломает кодировку емейла. Помогает полное комментирование тела функции _encodeHeader()