### PR TITLE
kcfinder: fix a silent blank page on critial errors

### DIFF
--- a/3rdparty/kcfinder/core/class/uploader.php
+++ b/3rdparty/kcfinder/core/class/uploader.php
@@ -696,7 +696,8 @@ class uploader {
     protected function callBack($url, $message="") {
         $message = text::jsValue($message);
 
-        if ((get_class($this) == "kcfinder\\browser") && ($this->action != "browser"))
+        if ((get_class($this) == "kcfinder\\browser")
+            && ($this->action !== null) && ($this->action != "browser"))
             return;
 
         if (isset($this->opener['name'])) {


### PR DESCRIPTION
Currently if there is a critical error during early object construction
the script just dies silently. This patch fixes it making sure that the
error message would be passed down and e.g. displayed in a message box.

See also
 * upstream PR: https://github.com/sunhater/kcfinder/pull/177
 * original issue repot [russian]:
   https://mjdm.ru/forum/viewtopic.php?f=24&t=6177