### PR TITLE
возможность использование символа ;

### DIFF
--- a/lib/objects.class.php
+++ b/lib/objects.class.php
@@ -1138,7 +1138,9 @@ function processTitle($title, $object = 0)
                     $data = getGlobal($m[1][$i] . '.' . $m[2][$i]);
                     if ($data == '') $data = 0;
                     $descr = $m[3][$i];
-                    $tmp = explode(';', $descr);
+                    $descr = preg_replace('#(?<!\\\)\;#', ";-;;-;", $descr); 
+                    $descr = preg_replace('#\\\;#', ";", $descr); 
+                    $tmp = explode(';-;;-;', $descr);
                     $totald = count($tmp);
                     $hsh = array();
                     if ($totald == 1) {

--- a/templates/scenes/scenes.tpl
+++ b/templates/scenes/scenes.tpl
@@ -606,8 +606,16 @@ $(".draggable" ).draggable({ cursor: "move", snap: true , snapTolerance: 5, grid
 
 
             function sceneZoom() {
-                zoom = $(window).width()/$("#slider").width()*100;
-                document.body.style.zoom = zoom+"%"
+                zoomw = $(window).width();
+                if(window.innerWidth > 0 && window.innerWidth < zoomw) zoomw = window.innerWidth;
+                zoomw = zoomw/$("#slider").width()*100;
+                zoomh = $(window).height();
+                if(window.innerHeight > 0 && window.innerHeight < zoomh) zoomh = window.innerHeight;
+                zoomh = zoomh/$("#slider").height()*100;
+                if(zoomh < zoomw)
+                    document.body.style.zoom = zoomh+"%"
+                else
+                    document.body.style.zoom = zoomw+"%"
             }
 
 


### PR DESCRIPTION
добавил возможность экранирования точки с запятой с помощью слэша в "processTitlePropertiesReplace"
чтобы она не считалась как разделитель значений а использовалась в выдаче
такое надо например когда в html style данные на лету формируешь:
img src='%.icon%' onClick='callMethod("%.switch");'
style='
%.startcolor|";filter: sepia(150%) saturate(500%) hue-rotate(%.colorstart%deg)\;"%
%.status|";filter: sepia(150%) saturate(500%) hue-rotate(%.color%deg)\;"%
%.imgbig|";width:%.imgwidth%px\;"%
'