### PR TITLE
Update common.class.php - for ClearScheduledJob('title%')

### DIFF
--- a/lib/common.class.php
+++ b/lib/common.class.php
@@ -408,7 +408,8 @@ function addScheduledJob($title, $commands, $datetime, $expire = 1800)
  */
 function clearScheduledJob($title)
 {
-    SQLExec("DELETE FROM jobs WHERE TITLE LIKE '" . DBSafe($title) . "'");
+    $title = str_replace("_", "\_", dbsafe1($title)); //dbfsafe1 не экранирует %, тут  добавил экранирование \_ (часто встречается в названиях джобов)	
+    SQLExec("DELETE FROM jobs WHERE TITLE LIKE '" . $title . "'");
 }
 
 /**


### PR DESCRIPTION
см. встроенные в МДМ функции --
заявлено
ClearScheduledJob('title'); -- **может использоваться маска типа "title%"**
Но функция DBSafe() экранирует символ подстановки в маске слэшем((
и, например,
SQLExec("DELETE FROM jobs FROM jobs WHERE TITLE LIKE '" . **DBSafe('motion%')** . "'") превращается в
SQLExec("DELETE FROM jobs FROM jobs WHERE TITLE WHERE TITLE LIKE **'motion\%'**), что не работает как ожидалось.
dbsafe1() не экранирует % и всем бы была хороша, но в случае like хорошо бы экранировать символ _, который часто используется в названиях джобов и, в то же время, является одиночной маской в mySQL