### PR TITLE
Скриншоты с камеры при работе из подкаталога.

### DIFF
--- a/modules/devices/SCameras_takeSeries.php
+++ b/modules/devices/SCameras_takeSeries.php
@@ -32,6 +32,10 @@ if (preg_match('/img src="(.+?)"/is',$body,$m)) {
 } else {
     $snapshotPreviewURL='';
 }
+$rootHTML=preg_replace('/\//', '\/', ROOTHTML);
+if (preg_match('/^' . $rootHTML . '/', $snapshotPreviewURL)) {
+    $snapshotPreviewURL=preg_replace('/^' . $rootHTML . '/', '/', $snapshotPreviewURL);
+}
 $image_url=BASE_URL.$snapshotPreviewURL;
 
 $new_width = 500;

--- a/modules/devices/SCameras_takeSnapshot.php
+++ b/modules/devices/SCameras_takeSnapshot.php
@@ -32,6 +32,10 @@ if (preg_match('/img src="(.+?)"/is',$body,$m)) {
 } else {
     $snapshotPreviewURL='';
 }
+$rootHTML=preg_replace('/\//', '\/', ROOTHTML);
+if (preg_match('/^' . $rootHTML . '/', $snapshotPreviewURL)) {
+    $snapshotPreviewURL=preg_replace('/^' . $rootHTML . '/', '/', $snapshotPreviewURL);
+}
 $image_url=BASE_URL.$snapshotPreviewURL;
 
 //echo $image_url."!";


### PR DESCRIPTION
При работе из подкаталога этот подкаталог учитывался два раза. Исправил таким не очень чистым способом, т.к. так и не понял где в $snapshotPreviewURL добавляется ROOTHTML, да и есть подозрение, что оно там добавляется неспроста.