### PR TITLE
Update common.class.php

### DIFF
--- a/lib/common.class.php
+++ b/lib/common.class.php
@@ -268,7 +268,7 @@ function timeNow($tm = 0)
         $tm = time();
     }
 
-    $h = (int)date('G', $tm);
+    $h = (strlen(strval($tm)) < 10) ? (int)gmdate('G', $tm) : (int)date('G', $tm);
     $m = (int)date('i', $tm);
     $ms = '';
 
@@ -280,7 +280,7 @@ function timeNow($tm = 0)
             $ms = $m . ' ' . getNumberWord($m, $array);
         }
     } else {
-        $hw = date('H:i', $tm);
+        $hw = (strlen(strval($tm)) < 10) ? (int)gmdate('H:i', $tm) : (int)date('H:i', $tm);
     }
 
     $res = trim($hw . " " . $ms);


### PR DESCRIPTION
Если функции **timeNow** передать Unix Timestamp не полного формата (менее 10, только часы и минуты), например **timeNow(32392) - 8:59**, функция вернет **11:59**, так как приплюсовывается часовая зона. Для не полного формата лучше использовать gmdate :)