### PR TITLE
Ремонт КаллметодСафе

### DIFF
--- a/modules/objects/objects.class.php
+++ b/modules/objects/objects.class.php
@@ -505,7 +505,23 @@ class objects extends module
             $params = array();
         }
         if (IsSet($_SERVER['REQUEST_URI']) && ($_SERVER['REQUEST_URI'] != '')) {
-            $result = $this->callMethod($name, $params);
+		    $data = array(
+				'object' => $this->object_title,
+				'op' => 'm',
+				'm' => $name,
+				'm_c_s' => $call_stack,
+			);
+			if (session_id()) {
+				$data[session_name()] = session_id();
+			}
+			$url = BASE_URL . '/objects/?' . http_build_query($data);
+			if (is_array($params)) {
+				foreach ($params as $k => $v) {
+					$url .= '&' . $k . '=' . urlencode($v);
+				}
+			}
+			$result = getURLBackground($url, 0);
+            //$result = $this->callMethod($name, $params);
         } else {
             $params['m_c_s'] = $call_stack;
             $result = callAPI('/api/method/' . urlencode($this->object_title . '.' . $name), 'GET', $params);


### PR DESCRIPTION
при таком коде в методе (заворот метода - специальный кросслинк)
```
DebMes('hby'  . serialize($params));
callMethodSafe('terminal_MAIN.MessageError', array('s' => 'taras', 'b' => 'sveta'));
```
И вызове его таким вызовом - callMethodSafe('terminal_MAIN.MessageError', array('s' => 'taras', 'b' => 'sveta'));

получаем ответ о крослинке и он соответственно не запускается
![image](https://user-images.githubusercontent.com/3198716/76602475-a974a780-6513-11ea-9d98-7e22a94e2609.png)

Причем передается и параметр стека вызова метода - 11:13:03 0.65022900 a:2:{i:0;s:59:"terminal_MAIN.MessageError.628a4ac9bd813d55112cb3224e42ddca";i:1;s:5:"proba";}
 
ТОТ ЖЕ результат и при вызове метода по ссылке... - http://127.0.0.1/objects/?object=terminal_MAIN&op=m&m=MessageError

![image](https://user-images.githubusercontent.com/3198716/76603269-5a2f7680-6515-11ea-823b-7d4aef80ffd5.png)
