### PR TITLE
Edit callMethodSafe

### DIFF
--- a/modules/objects/objects.class.php
+++ b/modules/objects/objects.class.php
@@ -504,12 +504,8 @@ class objects extends module
         if (!is_array($params)) {
             $params = array();
         }
-        if (IsSet($_SERVER['REQUEST_URI']) && ($_SERVER['REQUEST_URI'] != '')) {
-            $result = $this->callMethod($name, $params);
-        } else {
-            $params['m_c_s'] = $call_stack;
-            $result = callAPI('/api/method/' . urlencode($this->object_title . '.' . $name), 'GET', $params);
-        }
+        $params['m_c_s'] = $call_stack;
+        $result = callAPI('/api/method/' . urlencode($this->object_title . '.' . $name), 'GET', $params);
         endMeasure('callMethodSafe');
         return $result;
     }


### PR DESCRIPTION
Поскольку каллМетодСафе - всегда вызывается только как функция. То можно оставить только вызов ее через КАЛЛАПИ.
Вызов метода через урл - обрабатывается файлом /objects/index.php - то этого функция каллМетодСафе никак не касается..
И поскольку сам метод КАЛЛАПИ работает через отдельный поток - то соответственно каллМетодСафе ТОЖЕ будет работать через отдельный поток