### PR TITLE
Replace the params dict with the kwargs

### DIFF
--- a/lib/python/mjdm.py
+++ b/lib/python/mjdm.py
@@ -15,9 +15,7 @@ def getURL(url):
     response = urllib2.urlopen(url).read()
     return response
 
-def callAPI(api_url, method = "GET", params = ""):
-    if ((type(params) is not dict)):
-        params = {}
+def callAPI(api_url, method = "GET", **params):
 
     params['no_session']=1
     url = re.sub(r"^/api/", BASE_URL+ROOTHTML+'api.php/', api_url)
@@ -34,20 +32,16 @@ def callAPI(api_url, method = "GET", params = ""):
     #print the_page
     return the_page
 
-def runScript(script_name, params = ""):
-    if ((type(params) is not dict)):
-        params = {}
+def runScript(script_name, **params):
     callAPI("/api/script/"+script_name,"GET",params)
     return 1
 
-def callMethod(method_name, params = ""):
-    if ((type(params) is not dict)):
-        params = {}
+def callMethod(method_name, **params):
     callAPI("/api/method/"+method_name,"GET",params)
     return 1
 
 def setGlobal(property, value):
-    callAPI("/api/data/"+property, "POST", {"data":value})
+    callAPI("/api/data/"+property, "POST", data=value)
     return 1
 
 def sg(property, value):
@@ -87,8 +81,6 @@ class mjdObject:
         result =  getGlobal(self.object_name+"."+property_name)
         return result
 
-    def callMethod(self, method_name, params = ""):
-        if ((type(params) is not dict)):
-            params = {}
+    def callMethod(self, method_name, **params):
         result =  callMethod(self.object_name+"."+method_name, params)
         return result


### PR DESCRIPTION
Аргументы params="" были заменены на **params.
Таким образом, вместо
`callAPI("/api/data/"+property, "POST", {"data":value})`
используется:
`callAPI("/api/data/"+property, "POST", data=value)`