### PR TITLE
Update SSmoke_statusUpdated.php

### DIFF
--- a/modules/devices/SSmoke_statusUpdated.php
+++ b/modules/devices/SSmoke_statusUpdated.php
@@ -2,7 +2,8 @@
 
 $ot = $this->object_title;
 
-$this->setProperty('updated', time());
+$tm = time();
+$this->setProperty('updated', $tm);
 $this->setProperty('updatedText', date('H:i', $tm));
 
 $this->callMethod('keepAlive');


### PR DESCRIPTION
Свойство updatedText у датчика дыма всегда было 4:00, так как переменная $tm не принимала текущее значение времени и было не определено в коде.