### PR TITLE
Fix SButtons_pressed.php

### DIFF
--- a/modules/devices/SButtons_pressed.php
+++ b/modules/devices/SButtons_pressed.php
@@ -1,6 +1,9 @@
 <?php
 
 $ot = $this->object_title;
+
+$this->callMethodSafe('keepAlive');
+
 if (!isset($params['statusUpdated'])) {
   setTimeout($ot . '_pressed_status', '', 3);
   $this->setProperty('status', 1);


### PR DESCRIPTION
Для SButtons, метод keepAlive, не вызывался ни при изменении status, ни при вызове метода pressed