### PR TITLE
SAY: add id shouts in data for websocket

### DIFF
--- a/lib/messages.class.php
+++ b/lib/messages.class.php
@@ -104,7 +104,7 @@ function sayTo($ph, $level = 0, $destination = '')
     if ($level > 0) $rec['IMPORTANCE'] = $level;
     $rec['ID'] = SQLInsert('shouts', $rec);
 
-    $processed = processSubscriptionsSafe('SAYTO', array('level' => $level, 'message' => $ph, 'destination' => $destination));
+    $processed = processSubscriptionsSafe('SAYTO', array('id'=>$rec['ID'], 'level' => $level, 'message' => $ph, 'destination' => $destination));
     return 1;
 }
 
@@ -166,7 +166,7 @@ function say($ph, $level = 0, $member_id = 0, $source = '')
     $rec['ID'] = SQLInsert('shouts', $rec);
 
     if ($member_id) {
-        $processed = processSubscriptionsSafe('COMMAND', array('level' => $level, 'message' => $ph, 'member_id' => $member_id, 'source' => $source, 'image' => $image));
+        $processed = processSubscriptionsSafe('COMMAND', array('id'=>$rec['ID'], 'level' => $level, 'message' => $ph, 'member_id' => $member_id, 'source' => $source, 'image' => $image));
         return;
     }
 
@@ -194,7 +194,7 @@ function say($ph, $level = 0, $member_id = 0, $source = '')
         }
 
 
-        processSubscriptionsSafe('SAY', array('level' => $level, 'message' => $ph, 'member_id' => $member_id, 'image' => $image)); //, 'ignoreVoice'=>$ignoreVoice
+        processSubscriptionsSafe('SAY', array('id'=>$rec['ID'], 'level' => $level, 'message' => $ph, 'member_id' => $member_id, 'image' => $image)); //, 'ignoreVoice'=>$ignoreVoice
 
         if (defined('SETTINGS_HOOK_AFTER_SAY') && SETTINGS_HOOK_AFTER_SAY != '') {
             eval(SETTINGS_HOOK_AFTER_SAY);


### PR DESCRIPTION
Добавляется id сообщения при передаче в вебсокет. Необходим для однозначной идентификации сообщения при поиске дубликата