### PR TITLE
Openable Homebridge

### DIFF
--- a/modules/devices/devices_links_actions.inc.php
+++ b/modules/devices/devices_links_actions.inc.php
@@ -142,8 +142,8 @@ if (!$device1['SYSTEM_DEVICE'] && !$device1['ARCHIVED'] && $this->isHomeBridgeAv
                         DebMes("MQTT to_set : " . json_encode($payload), 'homebridge');
                     }
                     sg('HomeBridge.to_set', json_encode($payload));
-                    //$payload['characteristic'] = 'TargetPosition';
-                    //sg('HomeBridge.to_set', json_encode($payload));
+                    $payload['characteristic'] = 'TargetPosition';
+                    sg('HomeBridge.to_set', json_encode($payload));
                     unset($payload['service']);
                 }
             }

--- a/modules/devices/devices_links_actions.inc.php
+++ b/modules/devices/devices_links_actions.inc.php
@@ -134,9 +134,9 @@ if (!$device1['SYSTEM_DEVICE'] && !$device1['ARCHIVED'] && $this->isHomeBridgeAv
                 } elseif ($open_type == 'door' || $open_type == 'window' || $open_type == 'curtains' || $open_type == 'shutters') {
                     $payload['characteristic'] = 'CurrentPosition';
                     if (gg($device1['LINKED_OBJECT'] . '.status')) {
-                        $payload['value'] = "100";
-                    } else {
                         $payload['value'] = "0";
+                    } else {
+                        $payload['value'] = "100";
                     }
                     if ($debug_sync) {
                         DebMes("MQTT to_set : " . json_encode($payload), 'homebridge');

--- a/modules/devices/homebridgeSync.inc.php
+++ b/modules/devices/homebridgeSync.inc.php
@@ -85,13 +85,15 @@ for ($i = 0; $i < $total; $i++) {
                 } elseif ($open_type == 'door' || $open_type == 'window' || $open_type == 'curtains'  || $open_type == 'shutters') {
                     $payload['characteristic'] = 'CurrentPosition';
                     if (gg($devices[$i]['LINKED_OBJECT'] . '.status')) {
-                        $payload['value'] = "100";
+                        $payload['value'] = "0"; // открыто на 0% (закрыто)
                     } else {
-                        $payload['value'] = "0";
+                        $payload['value'] = "100"; // открыто на 100% (открыто)
                     }
                     sg('HomeBridge.to_set', json_encode($payload));
                     $payload['characteristic'] = 'TargetPosition';
-                    $payload['value'] = "100";
+                    sg('HomeBridge.to_set', json_encode($payload));
+                    $payload['characteristic'] = 'PositionState';
+                    $payload['value'] = "2"; //0 - "Закрывается" 1 - "Открывается" 2 - нет отображения
                     sg('HomeBridge.to_set', json_encode($payload));
                 }
             }

--- a/modules/devices/processHomebridgeMQTT.inc.php
+++ b/modules/devices/processHomebridgeMQTT.inc.php
@@ -89,9 +89,9 @@ if ($params['PROPERTY'] == 'from_get' && $device['ID']) {
                 if ($data['characteristic']=='CurrentPosition') {
                     $currentStatus = (int)gg($device['LINKED_OBJECT'] . '.status');
                     if ($currentStatus) {
-                        $payload['value'] = 100;
-                    } else {
                         $payload['value'] = 0;
+                    } else {
+                        $payload['value'] = 100;
                     }
                 }
             } elseif ($open_type == 'window') {
@@ -99,9 +99,9 @@ if ($params['PROPERTY'] == 'from_get' && $device['ID']) {
                 if ($data['characteristic']=='CurrentPosition') {
                     $currentStatus = (int)gg($device['LINKED_OBJECT'] . '.status');
                     if ($currentStatus) {
-                        $payload['value'] = 100;
-                    } else {
                         $payload['value'] = 0;
+                    } else {
+                        $payload['value'] = 100;
                     }
                 }
             } elseif ($open_type == 'curtains' || $open_type == 'shutters') {
@@ -109,9 +109,9 @@ if ($params['PROPERTY'] == 'from_get' && $device['ID']) {
                 if ($data['characteristic']=='CurrentPosition') {
                     $currentStatus = (int)gg($device['LINKED_OBJECT'] . '.status');
                     if ($currentStatus) {
-                        $payload['value'] = 100;
-                    } else {
                         $payload['value'] = 0;
+                    } else {
+                        $payload['value'] = 100;
                     }
                 }
             }


### PR DESCRIPTION
Исправление отображения дверей типа openable в HomeBridge/HomeKit.
Открыто на 0% - значит закрыто. Также передаются Target Position для визуального отображения и Position State при синхронизации для отключения состояний "Открывается"/"Закрывается".