### PR TITLE
Отказоустойчивость для систем без модуля CONNECT

### DIFF
--- a/modules/market/market.class.php
+++ b/modules/market/market.class.php
@@ -633,14 +633,16 @@ class market extends module
 
         $username = '';
         $password = '';
-        include_once(DIR_MODULES . 'connect/connect.class.php');
-        $connect = new connect();
-        $connect->getConfig();
-        $connect_username = strtolower($connect->config['CONNECT_USERNAME']);
-        $connect_password = $connect->config['CONNECT_PASSWORD'];
-        if ($connect_username != '' && $connect_password != '') {
-            $username = $connect_username;
-            $password = $connect_password;
+        @include_once(DIR_MODULES . 'connect/connect.class.php');
+        if (class_exists('connect')) {
+            $connect = new connect();
+            $connect->getConfig();
+            $connect_username = strtolower($connect->config['CONNECT_USERNAME']);
+            $connect_password = $connect->config['CONNECT_PASSWORD'];
+            if ($connect_username != '' && $connect_password != '') {
+                $username = $connect_username;
+                $password = $connect_password;
+            }
         }
         return getURL($data_url, $cache_timeout, $username, $password);
     }
@@ -967,14 +969,16 @@ class market extends module
         curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
         curl_setopt($ch, CURLOPT_FILE, $f);
 
-        include_once(DIR_MODULES . 'connect/connect.class.php');
-        $connect = new connect();
-        $connect->getConfig();
-        $connect_username = strtolower($connect->config['CONNECT_USERNAME']);
-        $connect_password = $connect->config['CONNECT_PASSWORD'];
-        if ($connect_username != '' && $connect_password != '') {
-            curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
-            curl_setopt($ch, CURLOPT_USERPWD, $connect_username . ":" . $connect_password);
+        @include_once(DIR_MODULES . 'connect/connect.class.php');
+        if (class_exists('connect')) {
+            $connect = new connect();
+            $connect->getConfig();
+            $connect_username = strtolower($connect->config['CONNECT_USERNAME']);
+            $connect_password = $connect->config['CONNECT_PASSWORD'];
+            if ($connect_username != '' && $connect_password != '') {
+                curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
+                curl_setopt($ch, CURLOPT_USERPWD, $connect_username . ":" . $connect_password);
+            }
         }
 
         $incoming = curl_exec($ch);


### PR DESCRIPTION
Системы не использующие CONNECT страдают от проблемы с неработающим циклом _connect_. Что в свою очередь выливается в красный статус на дашборде.
Удаление модуля _connect_ через менеджер модулей, в свою очередь, приводит к множественным рантайм-ошибкам на странице дашборда (из-за попытки модуля _market_ обратиться к классу _connect_).

Данный фикс добавляет отказоустойчивость и устраняет ошибки дашборда для систем без модуля _connect_.