### PR TITLE
Исправление ошибки на X-Ray закладке Производительность при пустом списке

### DIFF
--- a/modules/application.class.php
+++ b/modules/application.class.php
@@ -199,6 +199,9 @@ function getParams() {
     $this->redirect(ROOTHTML.'admin.php');
    }
 
+   if (file_exists(DIR_MODULES.'app_player')) {
+    $out['SHOW_PLAYER']=1;
+   }
 
    $terminals = getAllTerminals(-1, 'TITLE');
    $total=count($terminals);

--- a/modules/xray/xray.class.php
+++ b/modules/xray/xray.class.php
@@ -666,6 +666,7 @@ class xray extends module
 					$responce = [];
 					$responce['MODE'] = 'performance';
 					$responce['TOTAL'] = $total;
+					$responce['LIST'] = [];
 					
 					for ($i = 0; $i < $total; $i++) {
 						$responce['LIST'][$i]['OPERATION'] = htmlspecialchars($res[$i]['OPERATION']);

--- a/templates/default.html
+++ b/templates/default.html
@@ -32,9 +32,11 @@
                             </td>
                         </table>
                     </td>
+                    [#if SHOW_PLAYER=="1"#]
                     <td align="right">
                         [#module name="app_player" mode="header"#]
                     </td>
+                    [#endif#]
                     <td align="center">
                         <a href="<#ROOTHTML#>admin.php" class="btn btn-default btn-sm"><#LANG_CONTROL_PANEL#></a>
                     </td>


### PR DESCRIPTION
Когда список пустой, array_reverse падает с ошибкой что, в свою очередь, генерирует js-ошибку: 
**Uncaught SyntaxError: Unexpected token '<', "<br />**