### PR TITLE
Отказоустойчивость для систем без модуля app_player

### DIFF
--- a/modules/application.class.php
+++ b/modules/application.class.php
@@ -199,6 +199,9 @@ function getParams() {
     $this->redirect(ROOTHTML.'admin.php');
    }
 
+   if (file_exists(DIR_MODULES.'app_player')) {
+    $out['SHOW_PLAYER']=1;
+   }
 
    $terminals = getAllTerminals(-1, 'TITLE');
    $total=count($terminals);

--- a/templates/default.html
+++ b/templates/default.html
@@ -32,9 +32,11 @@
                             </td>
                         </table>
                     </td>
+                    [#if SHOW_PLAYER=="1"#]
                     <td align="right">
                         [#module name="app_player" mode="header"#]
                     </td>
+                    [#endif#]
                     <td align="center">
                         <a href="<#ROOTHTML#>admin.php" class="btn btn-default btn-sm"><#LANG_CONTROL_PANEL#></a>
                     </td>


### PR DESCRIPTION
Если в системе не нужен плеер, то нет возможности спрятать его в заголовке домашней страницы.
Удаление же модуля _app_player_ приводит к ошибке генерируемой на главной странице.

Данный фикс позволяет спрятать плеер с главной страницы путём удаления из системы модуля _app_player_.

(альтернативно, в качестве дополнительной фичи, можно вынести в системные настройки флажка "показывать плеер на домашней странице")