### PR TITLE
Fix bug on first save with PATTERN_TYPE=1

### DIFF
--- a/modules/patterns/patterns_edit.inc.php
+++ b/modules/patterns/patterns_edit.inc.php
@@ -172,6 +172,8 @@
 
     global $condition;
     $rec['CONDITION']=$condition;
+	   
+    if (strlen($rec['CONDITION']) == 0) $rec['CONDITION']=0;
 
     global $condition_value;
     $rec['CONDITION_VALUE']=$condition_value;


### PR DESCRIPTION
Если включен строгий режим, то при первом сохранении шаблона и выборе Типа=На основе значения свойств в template отсутствует input с навзанием condition, так как HTML генерировался для Типа=На основе сообщений