### PR TITLE
Update SMotions_motionDetected.php

### DIFF
--- a/modules/devices/SMotions_motionDetected.php
+++ b/modules/devices/SMotions_motionDetected.php
@@ -14,15 +14,18 @@ if (isset($params['VALUE']) && !$params['VALUE'] && !isset($params['statusUpdate
 }
 
 $motion_timeout = $this->getProperty('timeout'); // seconds timeout
-if (!$motion_timeout) {
+if (!$motion_timeout== "") {
     $motion_timeout = 20; // timeout by default
 }
+if ($motion_timeout) {
+    setTimeout($ot . '_motion_timer', 'setGlobal("' . $ot . '.status", 0);', $motion_timeout);
+}
+
 $nobodysHome = getGlobal('NobodyHomeMode.active');
 
 if (!isset($params['statusUpdated'])) {
     $this->setProperty('status', 1);
 }
-setTimeout($ot . '_motion_timer', 'setGlobal("' . $ot . '.status", 0);', $motion_timeout);
 
 if ($nobodysHome && $this->getProperty('ignoreNobodysHome')) {
     return;


### PR DESCRIPTION
Если "Время активности" в настройках ДД пустое, запускается таймер на 20 секунд (по умолчанию) для таймера окончания движения. Если в поле прописан 0 - таймер не запускается. Это нужно для того, чтобы не писать лишнюю запись об окончании движения в базу, если ДД сам шлет окончание движения.