### PR TITLE
Проблема со слишком длинным именем файла

### DIFF
--- a/modules/thumb/thumb.class.php
+++ b/modules/thumb/thumb.class.php
@@ -55,7 +55,7 @@ class thumb extends module
             $this->url = processTitle($this->url);
             $this->username = processTitle($this->username);
             $this->password = processTitle($this->password);
-            $filename = 'thumb_' . md5($this->url) . basename(preg_replace('/\W/', '', $this->url));
+            $filename = 'thumb_' . md5($this->url);
             if (preg_match('/\.cgi$/is', $filename)) {
                 $filename = str_replace('.cgi', '.jpg', $filename);
             }

--- a/modules/thumb/thumb.php
+++ b/modules/thumb/thumb.php
@@ -33,7 +33,7 @@ $debug_mode = gr('debug', 'int');
 if (isset($url) && $url != '') {
     $tmp_url = base64_decode($url);
     if (!$img) {
-        $filename = 'thumb_' . md5($tmp_url) . basename(preg_replace('/\W/', '', $tmp_url));
+        $filename = 'thumb_' . md5($tmp_url);
         $img = _I_CACHE_PATH . $filename;
     }
     if ($tmp_url == 'usb') {


### PR DESCRIPTION
В Zoneminder, чтобы получить кадр с камеры, получается довольно длинная ссылка. Для примера: http://zoneminder/zm/cgi-bin/zms?scale=50&mode=single&monitor=1&token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJab25lTWluZGVyIiwiaWF0IjoxNzI3MTM3NDIzLCJleHAiOjE3MjcxNDQ2MjMsInVzZXIiOiJtYWpvcmRvbW8iLCJ0eXBlIkoiYWNjZXNzIn0.SE-z1hj2q63ZMtUG8-Q2va9rukCy6SKO1OGHhxExCAA
Thumb пытался всё это запихать в название файла и упирался в максимальную длинну.
Т.к. этот файл, это чаще всего кэш, который будет куда-то пересохранён, решил, что префикса `thumb_` и md5sum из этой длинной строки будет достаточно.