### PR TITLE
feat(objects): add __updated property suffix support

### DIFF
--- a/modules/objects/objects.class.php
+++ b/modules/objects/objects.class.php
@@ -755,6 +755,23 @@ class objects extends module
         if (!$this->object_title) return false;
 
         $property = trim($property);
+
+        if (substr($property, -9) == '__updated') {
+            $source_property = substr($property, 0, -9);
+            if ($source_property == '') {
+                return '';
+            }
+
+            $value = SQLSelectOne("SELECT UPDATED FROM pvalues WHERE PROPERTY_NAME = '" . DBSafe($this->object_title . '.' . $source_property) . "'");
+            if (!isset($value['UPDATED'])) {
+                $id = $this->getPropertyByName($source_property, $this->class_id, $this->id);
+                if ($id) {
+                    $value = SQLSelectOne("SELECT UPDATED FROM pvalues WHERE PROPERTY_ID='" . (int)$id . "' AND OBJECT_ID='" . (int)$this->id . "'");
+                }
+            }
+            return isset($value['UPDATED']) ? $value['UPDATED'] : '';
+        }
+
         $cached_name = 'MJD:' . $this->object_title . '.' . $property;
 
         if ($property == 'object_title') {


### PR DESCRIPTION
## Summary

Adds support for reading the last update timestamp of an object property by requesting the property with the `__updated` suffix.
Легко получить время последнего обновления любого свойства без танцев с бубном, дополнительных методов и ненужных свойств "obj.updated"
например gg("room.temperature__updated") сразу возвращает время обновления в строковом формате, даже если у объекта нет никаких свойств .updated

## Changes

- Detects property names ending with `__updated` in object property lookup.
- Resolves the source property name by removing the suffix.
- Returns the `UPDATED` value from `pvalues`.
- Falls back to lookup by `PROPERTY_ID` and `OBJECT_ID` when direct lookup by `PROPERTY_NAME` is not found.

Change is limited to property lookup logic.