### PR TITLE
fix: dont use cache for __updated

### DIFF
--- a/lib/objects.class.php
+++ b/lib/objects.class.php
@@ -619,10 +619,14 @@ function getGlobal($varname)
     }
     $cached_name = 'MJD:' . $object_name . '.' . $varname;
 
-    if (strpos($varname, 'cycle_') === 0) {
+    $is_updated_meta_property = (substr($varname, -9) == '__updated');
+
+    if (!$is_updated_meta_property && strpos($varname, 'cycle_') === 0) {
         $cached_value = checkCycleFromCache($varname);
-    } else {
+    } elseif (!$is_updated_meta_property) {
         $cached_value = checkFromCache($cached_name);
+    } else {
+        $cached_value = false;
     }
     if ($cached_value !== false) {
         return returnTypedValue($cached_value);


### PR DESCRIPTION
## Summary

Adds a small guard in getGlobal() so __updated meta-properties are not read from cache.

### Why

__updated is derived from pvalues.UPDATED, not from a real property value. If cached, it can return stale timestamps after the source property changes.

### Change

Detects property names ending with __updated
Skips checkFromCache() / checkCycleFromCache() for those meta-properties
Leaves normal property caching unchanged