### PR TITLE
PHP8 fixes: lib/websockets/server/lib/WebSocket/Socket.php and lib/errors.class.php


### DIFF
--- a/lib/errors.class.php
+++ b/lib/errors.class.php
@@ -113,7 +113,9 @@ function majordomoGetErrorType($error_level = 0) {
         E_DEPRECATED => 'E_DEPRECATED',
         E_USER_DEPRECATED => 'E_USER_DEPRECATED',
     ];
-	if(phpversion() < 8) $error_names[E_STRICT] = 'E_STRICT';
+    if (defined('E_STRICT')) {
+        $error_names[E_STRICT] = 'E_STRICT';
+    }
     if (isset($error_names[$error_level])) {
         return $error_names[$error_level];
     } else {

--- a/lib/websockets/server/lib/WebSocket/Socket.php
+++ b/lib/websockets/server/lib/WebSocket/Socket.php
@@ -140,8 +140,10 @@ class Socket
 		$stringLength = strlen($string);
 		for($written = 0; $written < $stringLength; $written += $fwrite)
 		{
-                if (!is_resource($resource) || feof($resource)) { return false; }
-                $fwrite = @fwrite($resource, substr($string, $written));
+				if (!is_resource($resource) || feof($resource)) { return false; }
+				set_error_handler(function() { return true; });
+				$fwrite = fwrite($resource, substr($string, $written));
+				restore_error_handler();
 			if($fwrite === false)
 			{
 				return false;


### PR DESCRIPTION
- Suppress fwrite errors using set_error_handler instead of @ operator

- use defined ('E_STRICT') instead of phpversion() < 8 check