### PR TITLE
Улучшение проверки версии PHP для правильной обработки E_STRICT

### DIFF
--- a/lib/errors.class.php
+++ b/lib/errors.class.php
@@ -113,7 +113,9 @@ function majordomoGetErrorType($error_level = 0) {
         E_DEPRECATED => 'E_DEPRECATED',
         E_USER_DEPRECATED => 'E_USER_DEPRECATED',
     ];
-	if(phpversion() < 8) $error_names[E_STRICT] = 'E_STRICT';
+    if (PHP_VERSION_ID < 80000) {
+        $error_names[E_STRICT] = 'E_STRICT';
+    }
     if (isset($error_names[$error_level])) {
         return $error_names[$error_level];
     } else {
@@ -212,7 +214,6 @@ function majordomoErrorHandler($errno, $errmsg, $filename, $linenum)
 
     $errorCode = $errno;
     $errorType = majordomoGetErrorType($errorCode);
-    majordomoRememberCycleCrash("PHP $errorType: $errmsg in " . basename($filename) . ':' . (int)$linenum);
     $message = "PHP error level $errorCode $errorType in $filename (line $linenum):\n" . $errmsg . "\n";
 
     $message .= majordomoGetErrorDetails();
@@ -221,6 +222,7 @@ function majordomoErrorHandler($errno, $errmsg, $filename, $linenum)
             majordomoSaveError($message, 'php_warnings');
         }
     } else {
+        majordomoRememberCycleCrash("PHP $errorType: $errmsg in " . basename($filename) . ':' . (int)$linenum);
         majordomoSaveError($message, 'php_errors');
     }
 }

--- a/lib/errors.class.php
+++ b/lib/errors.class.php
@@ -125,7 +125,6 @@ function majordomoGetErrorType($error_level = 0) {
 
 function majordomoGetErrorDetails($e = 0)
 {
-
     if (isset($_SERVER['REQUEST_URI'])) {
         $message = "URL: " . $_SERVER['REQUEST_URI'];
     } else {
@@ -135,8 +134,6 @@ function majordomoGetErrorDetails($e = 0)
             $message .= "\nArguments:" . implode(' ', $argv);
         }
     }
-
-
 
     $error = error_get_last();
     if (is_array($error)) {
@@ -214,6 +211,7 @@ function majordomoErrorHandler($errno, $errmsg, $filename, $linenum)
 
     $errorCode = $errno;
     $errorType = majordomoGetErrorType($errorCode);
+    majordomoRememberCycleCrash("PHP $errorType: $errmsg in " . basename($filename) . ':' . (int)$linenum);
     $message = "PHP error level $errorCode $errorType in $filename (line $linenum):\n" . $errmsg . "\n";
 
     $message .= majordomoGetErrorDetails();
@@ -222,7 +220,6 @@ function majordomoErrorHandler($errno, $errmsg, $filename, $linenum)
             majordomoSaveError($message, 'php_warnings');
         }
     } else {
-        majordomoRememberCycleCrash("PHP $errorType: $errmsg in " . basename($filename) . ':' . (int)$linenum);
         majordomoSaveError($message, 'php_errors');
     }
 }


### PR DESCRIPTION
Строка 116: phpversion() возвращает строку ("X.X.XX"), а сравнение строк с числом не корректно, правильнее использовать предопределённую константу [PHP_VERSION_ID](https://www.php.net/manual/en/reserved.constants.php#constant.php-version-id).
#1182 @whitevast 

