### PR TITLE
Улучшение работы цикла Websocket, уменьшение нагрузки на систему

### DIFF
--- a/lib/websockets/server/lib/WebSocket/Server.php
+++ b/lib/websockets/server/lib/WebSocket/Server.php
@@ -83,7 +83,7 @@ class Server extends Socket
                         $write           = null;
                         $except          = null;
 
-                        $num_changed = @stream_select($changed_sockets, $write, $except, 0, 5000);
+                        $num_changed = @stream_select($changed_sockets, $write, $except, 0, 500000);
                         if ($num_changed === false) {
                                 $this->log('[warn] stream_select() failed, cleaning sockets');
                                 foreach ($this->clients as $key => $client) {


### PR DESCRIPTION
fix: stream_select timeout was 0.005 sec (5000µs) causing ~200 idle iterations/sec and elevated load average. Changed to 0.5 sec (500ms) — reduces scheduler pressure 100x while keeping connection latency imperceptible for home automation use.