### PR TITLE
Improve error class constructor for server variables

### DIFF
--- a/lib/errors.class.php
+++ b/lib/errors.class.php
@@ -41,7 +41,7 @@ class custom_error
      */
     public function __construct($description, $stop = 0)
     {
-        $script = 'http://' . $_SERVER['SERVER_NAME'] . $_SERVER['REQUEST_URI'];
+        $script = 'http://' . ($_SERVER['SERVER_NAME'] ?? '') . ($_SERVER['REQUEST_URI'] ?? '');
 
         if (!mb_detect_encoding($description, 'UTF-8', true)) {
             $description = iconv('windows-1251', 'UTF-8', $description);


### PR DESCRIPTION
Use null coalescing operator to handle potential undefined server variables.

Улучшение логироваия ошибок: при запуске из CLI (а это все scripts/cycle_*.php, запускаемые exec php -q ...) в момент обработки E_ERROR/E_PARSE/E_COMPILE_ERROR phpShutDownFunction() создаётся custom_error. конструктор ошибки на строке 44 читает $_SERVER['SERVER_NAME'] и $_SERVER['REQUEST_URI'], которых в CLI нет.
На PHP 8 + это даёт E_WARNING: Undefined array key.
В итоге реальная ошибка не логируется.
После исправления, ?? подставляет '', когда ключа нет, Warning не рождается → majordomoRememberCycleCrash() не вызывается для него → {cycle}LastError сохраняет в лог настоящую причину падения.